### PR TITLE
dev/future-update

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 
 group 'com.shanebeestudios'
 
-compileJava   {
+compileJava {
     sourceCompatibility = '17'
     targetCompatibility = '17'
     options.encoding = 'UTF-8'
@@ -31,7 +31,7 @@ repositories {
 
 dependencies {
     // Paper
-    compileOnly("io.papermc.paper:paper-api:1.20.1-R0.1-SNAPSHOT")
+    compileOnly("io.papermc.paper:paper-api:1.20.4-R0.1-SNAPSHOT")
 
     // Skript
     compileOnly(group: 'com.github.SkriptLang', name: 'Skript', version: '2.7.0') {
@@ -39,10 +39,10 @@ dependencies {
     }
 
     // Command Api
-    implementation("dev.jorel:commandapi-bukkit-shade:9.3.0")
+    implementation("dev.jorel:commandapi-bukkit-shade:9.4.0")
 
     // SkBee
-    compileOnly("com.github.ShaneBeee:SkBee:2.17.0")
+    compileOnly("com.github.ShaneBeee:SkBee:3.4.3")
 }
 
 build {
@@ -61,6 +61,9 @@ processResources {
 
 shadowJar {
     archiveClassifier = null
+    dependencies {
+        include dependency("dev.jorel:commandapi-bukkit-shade:9.4.0")
+    }
     relocate("dev.jorel.commandapi", "com.shanebeestudios.briggy.api.commandapi")
 }
 
@@ -68,5 +71,5 @@ shadowJar {
 tasks.register('server', Copy) {
     from shadowJar
     // Change this to wherever you want your jar to build
-    into '/Users/ShaneBee/Desktop/Server/Skript/1-20-4/plugins'
+    into '/Users/ShaneBee/Desktop/Server/Skript/1-20-6/plugins'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ compileJava {
 }
 
 // SkBriggy version
-version = '1.2.0'
+version = '1.3.0'
 
 repositories {
     mavenCentral()

--- a/src/main/java/com/shanebeestudios/briggy/SkBriggy.java
+++ b/src/main/java/com/shanebeestudios/briggy/SkBriggy.java
@@ -26,7 +26,7 @@ public class SkBriggy extends JavaPlugin {
     @Override
     public void onLoad() {
         try {
-            CommandAPIBukkitConfig commandAPIBukkitConfig = new CommandAPIBukkitConfig(this);
+            CommandAPIBukkitConfig commandAPIBukkitConfig = new CommandAPIBukkitConfig(this).silentLogs(true);
             if (Bukkit.getPluginManager().getPlugin("SkBee") != null && MinecraftVersion.getVersion() != MinecraftVersion.UNKNOWN) {
                 commandAPIBukkitConfig.initializeNBTAPI(NBTContainer.class, NBTContainer::new);
             }

--- a/src/main/java/com/shanebeestudios/briggy/SkBriggy.java
+++ b/src/main/java/com/shanebeestudios/briggy/SkBriggy.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 
 public class SkBriggy extends JavaPlugin {
 
+    private static SkBriggy INSTANCE;
     private static boolean commandApiCanLoad;
 
     @Override
@@ -42,6 +43,7 @@ public class SkBriggy extends JavaPlugin {
     @SuppressWarnings("deprecation")
     @Override
     public void onEnable() {
+        INSTANCE = this;
         PluginManager pluginManager = Bukkit.getPluginManager();
         if (!commandApiCanLoad) {
             Utils.log("&eIt appears the CommandAPI is not available on your server version.");
@@ -103,6 +105,11 @@ public class SkBriggy extends JavaPlugin {
     @Override
     public void onDisable() {
         CommandAPI.onDisable();
+        INSTANCE = null;
+    }
+
+    public static SkBriggy getInstance() {
+        return INSTANCE;
     }
 
 }

--- a/src/main/java/com/shanebeestudios/briggy/api/BrigArgument.java
+++ b/src/main/java/com/shanebeestudios/briggy/api/BrigArgument.java
@@ -28,7 +28,6 @@ import dev.jorel.commandapi.arguments.OfflinePlayerArgument;
 import dev.jorel.commandapi.arguments.ParticleArgument;
 import dev.jorel.commandapi.arguments.PotionEffectArgument;
 import dev.jorel.commandapi.arguments.RecipeArgument;
-import dev.jorel.commandapi.arguments.RotationArgument;
 import dev.jorel.commandapi.arguments.SoundArgument;
 import dev.jorel.commandapi.arguments.StringArgument;
 import dev.jorel.commandapi.arguments.TeamArgument;
@@ -64,6 +63,7 @@ public class BrigArgument {
         register("biome", BiomeArgument.class);
         register("biomekey", "biome[ ]key", BiomeArgument.NamespacedKey.class);
         register("block state", "block[[ ](state|data)]", BlockStateArgument.class);
+        register("blockpredicate", "block[ ]predicate", CustomArg.BLOCK_PREDICATE);
         register("blockpos", "block[ ]pos", CustomArg.BLOCK_POS);
         register("command", CommandArgument.class);
         register("component", CustomArg.COMPONENT);
@@ -71,6 +71,7 @@ public class BrigArgument {
         register("enchantment", "enchant[ment]", EnchantmentArgument.class);
         register("entitytype", EntityTypeArgument.class);
         register("itemstack", "item[[ ]stack]", ItemStackArgument.class);
+        register("itempredicate", "item[[ ]stack][ ]predicate", CustomArg.ITEM_STACK_PREDICATE);
         register("loottable", "loot[ ]table", LootTableArgument.class);
         register("message", CustomArg.MESSAGE);
         register("nbt", CustomArg.NBT);

--- a/src/main/java/com/shanebeestudios/briggy/api/BrigCommand.java
+++ b/src/main/java/com/shanebeestudios/briggy/api/BrigCommand.java
@@ -4,7 +4,6 @@ import ch.njol.skript.lang.Trigger;
 import ch.njol.skript.variables.Variables;
 import com.shanebeestudios.briggy.api.event.BrigCommandTriggerEvent;
 import com.shanebeestudios.briggy.api.util.ObjectConverter;
-import com.shanebeestudios.briggy.api.util.Utils;
 import dev.jorel.commandapi.CommandAPICommand;
 import dev.jorel.commandapi.arguments.Argument;
 
@@ -90,7 +89,6 @@ public class BrigCommand {
         });
 
         commandAPICommand.register();
-        Utils.reloadCommands();
     }
 
 }

--- a/src/main/java/com/shanebeestudios/briggy/api/CustomArg.java
+++ b/src/main/java/com/shanebeestudios/briggy/api/CustomArg.java
@@ -32,6 +32,7 @@ import org.bukkit.World;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
+import java.util.concurrent.CompletableFuture;
 
 public abstract class CustomArg {
 
@@ -140,8 +141,9 @@ public abstract class CustomArg {
         Argument<World> get(String name) {
             return new CustomArgument<>(new StringArgument(name), info ->
                     Bukkit.getWorld(info.input()))
-                    .replaceSuggestions(ArgumentSuggestions.strings(
-                            Bukkit.getWorlds().stream().map(World::getName).toArray(String[]::new)));
+                    .includeSuggestions(ArgumentSuggestions.stringCollectionAsync(commandSenderSuggestionInfo ->
+                            CompletableFuture.supplyAsync(() -> Bukkit.getWorlds().stream().map(World::getName).toList())));
+
         }
     };
 

--- a/src/main/java/com/shanebeestudios/briggy/api/CustomArg.java
+++ b/src/main/java/com/shanebeestudios/briggy/api/CustomArg.java
@@ -3,13 +3,17 @@ package com.shanebeestudios.briggy.api;
 import ch.njol.skript.aliases.ItemType;
 import ch.njol.skript.util.SkriptColor;
 import com.shanebeestudios.briggy.SkBriggy;
+import com.shanebeestudios.briggy.api.wrapper.BlockPredicate;
+import com.shanebeestudios.briggy.api.wrapper.ItemStackPredicate;
 import com.shanebeestudios.skbee.api.nbt.NBTApi;
 import com.shanebeestudios.skbee.api.wrapper.ComponentWrapper;
 import dev.jorel.commandapi.arguments.AdventureChatArgument;
 import dev.jorel.commandapi.arguments.AdventureChatComponentArgument;
 import dev.jorel.commandapi.arguments.Argument;
 import dev.jorel.commandapi.arguments.ArgumentSuggestions;
+import dev.jorel.commandapi.arguments.BlockPredicateArgument;
 import dev.jorel.commandapi.arguments.CustomArgument;
+import dev.jorel.commandapi.arguments.ItemStackPredicateArgument;
 import dev.jorel.commandapi.arguments.Location2DArgument;
 import dev.jorel.commandapi.arguments.LocationArgument;
 import dev.jorel.commandapi.arguments.LocationType;
@@ -52,6 +56,14 @@ public abstract class CustomArg {
         }
     };
 
+    static final CustomArg BLOCK_PREDICATE = new CustomArg() {
+        @SuppressWarnings("unchecked")
+        @Override
+        Argument<?> get(String name) {
+            return new CustomArgument<>(new BlockPredicateArgument(name), info -> new BlockPredicate(info.currentInput()));
+        }
+    };
+
     static final CustomArg COMPONENT = new CustomArg() {
         @Override
         Argument<?> get(String name) {
@@ -60,6 +72,14 @@ public abstract class CustomArg {
                 if (SkBriggy.HAS_SKBEE_COMPONENT) return ComponentWrapper.fromComponent(component);
                 return LegacyComponentSerializer.legacySection().serialize(component);
             });
+        }
+    };
+
+    static final CustomArg ITEM_STACK_PREDICATE = new CustomArg() {
+        @SuppressWarnings({"unused", "unchecked"})
+        @Override
+        Argument<?> get(String name) {
+            return new CustomArgument<>(new ItemStackPredicateArgument(name), info -> new ItemStackPredicate(info.currentInput()));
         }
     };
 
@@ -100,7 +120,7 @@ public abstract class CustomArg {
         Argument<?> get(String name) {
             return new CustomArgument<>(new RotationArgument(name), info -> {
                 Rotation rotation = info.currentInput();
-                return new Location(MAIN_WORLD, 0,0,0, rotation.getNormalizedYaw(), rotation.getNormalizedPitch());
+                return new Location(MAIN_WORLD, 0, 0, 0, rotation.getNormalizedYaw(), rotation.getNormalizedPitch());
             });
         }
     };

--- a/src/main/java/com/shanebeestudios/briggy/api/event/BrigCommandSuggestEvent.java
+++ b/src/main/java/com/shanebeestudios/briggy/api/event/BrigCommandSuggestEvent.java
@@ -13,9 +13,18 @@ import java.util.List;
 public class BrigCommandSuggestEvent extends BrigCommandEvent {
 
     private final List<IStringTooltip> tooltips = new ArrayList<>();
+    private Object[] args;
 
     public BrigCommandSuggestEvent(@NotNull BrigCommand brigCommand, @Nullable CommandSender sender) {
         super(brigCommand, sender);
+    }
+
+    public Object[] getArgs() {
+        return args;
+    }
+
+    public void setArgs(Object[] args) {
+        this.args = args;
     }
 
     public List<IStringTooltip> getTooltips() {

--- a/src/main/java/com/shanebeestudios/briggy/api/wrapper/BlockPredicate.java
+++ b/src/main/java/com/shanebeestudios/briggy/api/wrapper/BlockPredicate.java
@@ -1,0 +1,19 @@
+package com.shanebeestudios.briggy.api.wrapper;
+
+import org.bukkit.block.Block;
+
+import java.util.function.Predicate;
+
+public class BlockPredicate implements Predicate<Block> {
+
+    private final Predicate<Block> predicate;
+
+    public BlockPredicate(Predicate<Block> predicate) {
+        this.predicate = predicate;
+    }
+
+    @Override
+    public boolean test(Block block) {
+        return this.predicate.test(block);
+    }
+}

--- a/src/main/java/com/shanebeestudios/briggy/api/wrapper/ItemStackPredicate.java
+++ b/src/main/java/com/shanebeestudios/briggy/api/wrapper/ItemStackPredicate.java
@@ -1,0 +1,20 @@
+package com.shanebeestudios.briggy.api.wrapper;
+
+import org.bukkit.inventory.ItemStack;
+
+import java.util.function.Predicate;
+
+public class ItemStackPredicate implements Predicate<ItemStack> {
+
+    private final Predicate<ItemStack> predicate;
+
+    public ItemStackPredicate(Predicate<ItemStack> predicate) {
+        this.predicate = predicate;
+    }
+
+    @Override
+    public boolean test(ItemStack itemStack) {
+        return this.predicate.test(itemStack);
+    }
+
+}

--- a/src/main/java/com/shanebeestudios/briggy/skript/conditions/CondPredicateMatch.java
+++ b/src/main/java/com/shanebeestudios/briggy/skript/conditions/CondPredicateMatch.java
@@ -41,7 +41,7 @@ import java.util.function.Predicate;
         "\t\tloop blocks in radius {_rad} around target block of player:",
         "\t\t\tif loop-block matches block predicate {_b}:",
         "\t\t\t\tset loop-block to {_block}"})
-@Since("INSERT VERSION")
+@Since("1.3.0")
 public class CondPredicateMatch extends Condition {
 
     static {

--- a/src/main/java/com/shanebeestudios/briggy/skript/conditions/CondPredicateMatch.java
+++ b/src/main/java/com/shanebeestudios/briggy/skript/conditions/CondPredicateMatch.java
@@ -1,0 +1,86 @@
+package com.shanebeestudios.briggy.skript.conditions;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.lang.Condition;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.util.Checker;
+import ch.njol.util.Kleenean;
+import com.shanebeestudios.briggy.api.wrapper.BlockPredicate;
+import com.shanebeestudios.briggy.api.wrapper.ItemStackPredicate;
+import org.bukkit.block.Block;
+import org.bukkit.event.Event;
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.function.Predicate;
+
+@Name("Predicate - Matches")
+@Description("Check if a block/item matches a predicate.")
+@Examples({"# /remove @a #wool",
+        "# /remove @a #minecraft:swords{Damage:0}",
+        "brig command /remove <players> <i:itempredicate>:",
+        "\ttrigger:",
+        "\t\tloop {_players::*}:",
+        "\t\t\tloop items in inventory of loop-value:",
+        "\t\t\t\tif loop-item matches item predicate {_i}:",
+        "\t\t\t\t\tremove loop-item from inventory of loop-value-1",
+        "",
+        "# /replace minecraft:short_grass minecraft:air 20",
+        "# /replace #minecraft:dirt minecraft:sand 30",
+        "# /replace #minecraft:logs minecraft:stone 50",
+        "brig command /replace <b:blockpredicate> <block> [<rad:int>]:",
+        "\ttrigger:",
+        "\t\tif {_rad} is not set:",
+        "\t\t\tset {_rad} to 5",
+        "\t\tloop blocks in radius {_rad} around target block of player:",
+        "\t\t\tif loop-block matches block predicate {_b}:",
+        "\t\t\t\tset loop-block to {_block}"})
+@Since("INSERT VERSION")
+public class CondPredicateMatch extends Condition {
+
+    static {
+        Skript.registerCondition(CondPredicateMatch.class,
+                "%itemstacks/blocks% match[es] (item|block) predicate %predicate%",
+                "%itemstacks/blocks% (doesn't|don't|do not) match[es] (item|block) predicate %predicate%");
+    }
+
+    private Expression<?> objects;
+    private Expression<Predicate<?>> predicate;
+
+    @SuppressWarnings({"NullableProblems", "unchecked"})
+    @Override
+    public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean kleenean, ParseResult parseResult) {
+        this.objects = exprs[0];
+        this.predicate = (Expression<Predicate<?>>) exprs[1];
+        setNegated(matchedPattern == 1);
+        return true;
+    }
+
+    @SuppressWarnings("NullableProblems")
+    @Override
+    public boolean check(Event event) {
+        if (this.predicate == null) return false;
+        Predicate<?> predicate = this.predicate.getSingle(event);
+        return this.objects.check(event, (Checker<Object>) object -> {
+            if (object instanceof ItemStack itemStack && predicate instanceof ItemStackPredicate itemStackPredicate) {
+                return itemStackPredicate.test(itemStack);
+            } else if (object instanceof Block block && predicate instanceof BlockPredicate blockPredicate) {
+                return blockPredicate.test(block);
+            }
+            return false;
+        }, isNegated());
+    }
+
+    @Override
+    public @NotNull String toString(@Nullable Event e, boolean d) {
+        String match = isNegated() ? (this.objects.isSingle() ? "doesn't match" : "don't match") : (this.objects.isSingle() ? "matches" : "match");
+        return String.format("%s %s predicate %s", this.objects.toString(e, d), match, this.predicate.toString(e, d));
+    }
+
+}

--- a/src/main/java/com/shanebeestudios/briggy/skript/expressions/ExprPredicateFilter.java
+++ b/src/main/java/com/shanebeestudios/briggy/skript/expressions/ExprPredicateFilter.java
@@ -38,10 +38,10 @@ import java.util.function.Predicate;
         "\t\tloop {_players::*}:",
         "\t\t\tremove ((items in loop-value's inventory) that match item predicate {_i}) from inventory of loop-value"})
 @Since("INSERT VERSION")
-public class ExprPredicateMatch extends SimpleExpression<Object> {
+public class ExprPredicateFilter extends SimpleExpression<Object> {
 
     static {
-        Skript.registerExpression(ExprPredicateMatch.class, Object.class, ExpressionType.COMBINED,
+        Skript.registerExpression(ExprPredicateFilter.class, Object.class, ExpressionType.COMBINED,
                 "%itemstacks% (that|which) match item[[ ]stack] predicate %predicate%",
                 "%blocks% (that|which) match block predicate %predicate%");
     }

--- a/src/main/java/com/shanebeestudios/briggy/skript/expressions/ExprPredicateFilter.java
+++ b/src/main/java/com/shanebeestudios/briggy/skript/expressions/ExprPredicateFilter.java
@@ -37,7 +37,7 @@ import java.util.function.Predicate;
         "\ttrigger:",
         "\t\tloop {_players::*}:",
         "\t\t\tremove ((items in loop-value's inventory) that match item predicate {_i}) from inventory of loop-value"})
-@Since("INSERT VERSION")
+@Since("1.3.0")
 public class ExprPredicateFilter extends SimpleExpression<Object> {
 
     static {

--- a/src/main/java/com/shanebeestudios/briggy/skript/expressions/ExprPredicateMatch.java
+++ b/src/main/java/com/shanebeestudios/briggy/skript/expressions/ExprPredicateMatch.java
@@ -1,0 +1,101 @@
+package com.shanebeestudios.briggy.skript.expressions;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.ExpressionType;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.skript.lang.util.SimpleExpression;
+import ch.njol.util.Kleenean;
+import com.shanebeestudios.briggy.api.wrapper.BlockPredicate;
+import com.shanebeestudios.briggy.api.wrapper.ItemStackPredicate;
+import org.bukkit.block.Block;
+import org.bukkit.event.Event;
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.function.Predicate;
+
+@Name("Predicate - Filter")
+@Description("Represents a item/block predicate for filtering objects.")
+@Examples({"# /destroy minecraft:short_grass 10",
+        "# /destroy #minecraft:stairs 50",
+        "brig command /destroy <b:blockpredicate> [<rad:int>]:",
+        "\ttrigger:",
+        "\t\tif {_rad} is not set:",
+        "\t\t\tset {_rad} to 5",
+        "\t\tloop ((blocks in radius {_rad} around target block) that match block predicate {_b}):",
+        "\t\t\tbreak loop-block",
+        "",
+        "# /remove @a #minecraft:swords",
+        "# /remove @a #minecraft:swords{Damage:0}",
+        "brig command /remove <players> <i:itempredicate>:",
+        "\ttrigger:",
+        "\t\tloop {_players::*}:",
+        "\t\t\tremove ((items in loop-value's inventory) that match item predicate {_i}) from inventory of loop-value"})
+@Since("INSERT VERSION")
+public class ExprPredicateMatch extends SimpleExpression<Object> {
+
+    static {
+        Skript.registerExpression(ExprPredicateMatch.class, Object.class, ExpressionType.COMBINED,
+                "%itemstacks% (that|which) match item[[ ]stack] predicate %predicate%",
+                "%blocks% (that|which) match block predicate %predicate%");
+    }
+
+    private int pattern;
+    private Expression<ItemStack> itemStacks;
+    private Expression<Block> blocks;
+    private Expression<Predicate<?>> predicate;
+
+    @SuppressWarnings({"NullableProblems", "unchecked"})
+    @Override
+    public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean kleenean, ParseResult parseResult) {
+        this.pattern = matchedPattern;
+        if (matchedPattern == 0) {
+            this.itemStacks = (Expression<ItemStack>) exprs[0];
+        } else {
+            this.blocks = (Expression<Block>) exprs[0];
+        }
+        this.predicate = (Expression<Predicate<?>>) exprs[1];
+        return true;
+    }
+
+    @SuppressWarnings({"NullableProblems"})
+    @Override
+    protected @Nullable Object[] get(Event event) {
+        if (this.predicate == null) return null;
+
+        Predicate<?> predicate = this.predicate.getSingle(event);
+        if (predicate == null) return null;
+
+        if (this.pattern == 0 && predicate instanceof ItemStackPredicate itemStackPredicate) {
+            return this.itemStacks.stream(event).filter(itemStackPredicate).toArray();
+        } else if (this.pattern == 1 && predicate instanceof BlockPredicate blockPredicate) {
+            return this.blocks.stream(event).filter(blockPredicate).toArray();
+        }
+        return null;
+    }
+
+    @Override
+    public boolean isSingle() {
+        return false;
+    }
+
+    @Override
+    public @NotNull Class<?> getReturnType() {
+        return this.pattern == 0 ? ItemStack.class : Block.class;
+    }
+
+    @Override
+    public @NotNull String toString(@Nullable Event e, boolean d) {
+        String message = "%s that match %s predicate %s";
+        String object = this.pattern == 0 ? this.itemStacks.toString(e, d) : this.blocks.toString(e, d);
+        String type = this.pattern == 0 ? "item" : "block";
+        return String.format(message, object, type, this.predicate.toString(e, d));
+    }
+
+}

--- a/src/main/java/com/shanebeestudios/briggy/skript/structures/StructBrigCommand.java
+++ b/src/main/java/com/shanebeestudios/briggy/skript/structures/StructBrigCommand.java
@@ -41,6 +41,7 @@ import java.util.regex.Pattern;
 
 @Name("Brig Command")
 @Description({"Register a new Brigadier command.",
+        "See wiki for more details on registering: <link>https://github.com/ShaneBeee/SkBriggy/wiki/Registering-New-Command</link>",
         "\nNotes:",
         "\nFormat: 'brig command /commandName <brigArgType> [<brigArgType(optional)>] <argName:brigArgType> [<argName:brigArgType(optional)>]:'",
         "\n`commandName` = Represents the command itself, ex: '/mycommand'.",
@@ -92,7 +93,7 @@ public class StructBrigCommand extends Structure {
                 .addSection("arguments", true)
                 .addSection("trigger", false)
                 .build();
-        Skript.registerStructure(StructBrigCommand.class, entryValidator, "brig[gy] command /<.+>");
+        Skript.registerStructure(StructBrigCommand.class, entryValidator, "brig[(gy|adier)] command /<.+>");
     }
 
     private String command;
@@ -237,7 +238,7 @@ public class StructBrigCommand extends Structure {
 
             // GreedyString args have to be last
             List<Argument<?>> brigArgs = brigCommand.getArguments();
-            if (brigArgs.size() > 0 && brigArgs.get(brigArgs.size() - 1) instanceof GreedyStringArgument) {
+            if (!brigArgs.isEmpty() && brigArgs.get(brigArgs.size() - 1) instanceof GreedyStringArgument) {
                 Skript.error("You cannot place another arg after a <greedystring> arg.");
                 return false;
             }

--- a/src/main/java/com/shanebeestudios/briggy/skript/structures/StructBrigCommand.java
+++ b/src/main/java/com/shanebeestudios/briggy/skript/structures/StructBrigCommand.java
@@ -14,6 +14,7 @@ import ch.njol.skript.lang.VariableString;
 import ch.njol.skript.lang.util.SimpleEvent;
 import ch.njol.skript.util.Utils;
 import ch.njol.util.StringUtils;
+import com.shanebeestudios.briggy.SkBriggy;
 import com.shanebeestudios.briggy.api.BrigArgument;
 import com.shanebeestudios.briggy.api.BrigCommand;
 import com.shanebeestudios.briggy.api.event.BrigCommandArgumentsEvent;
@@ -22,6 +23,7 @@ import dev.jorel.commandapi.CommandAPI;
 import dev.jorel.commandapi.arguments.Argument;
 import dev.jorel.commandapi.arguments.GreedyStringArgument;
 import dev.jorel.commandapi.arguments.MultiLiteralArgument;
+import org.bukkit.Bukkit;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -41,58 +43,59 @@ import java.util.regex.Pattern;
 
 @Name("Brig Command")
 @Description({"Register a new Brigadier command.",
-        "See wiki for more details on registering: <link>https://github.com/ShaneBeee/SkBriggy/wiki/Registering-New-Command</link>",
-        "\nNotes:",
-        "\nFormat: 'brig command /commandName <brigArgType> [<brigArgType(optional)>] <argName:brigArgType> [<argName:brigArgType(optional)>]:'",
-        "\n`commandName` = Represents the command itself, ex: '/mycommand'.",
-        "\n`brigArgType` = Represents a brig argument type.",
-        "While some may match Skript types, this doesn't actually support Skript types.",
-        "\n`argName` = The name of the arg, which will be used to create a local variable for the arg.",
-        "In some cases this will show when typing out a command in game.",
-        "If this isn't set a local variable will be created using the type (see examples).",
-        "\nJust like Skript commands, wrapping your arg in `[]` makes it optional. Do note at this time there is no support for defaults.",
-        "\n",
-        "\nEntries and Sections:",
-        "\n`permission:` = Just like Skript, the permission the player will require for this command.",
-        "\n`description:` = Just like Skript, this is a string that will be used in the help command.",
-        "\n`arguments:` = Section for registering arguments. See `Register Argument` effect.",
-        "\n`trigger:` = Section, just like Skript, for executing your code in the command."})
+    "See wiki for more details on registering: <link>https://github.com/ShaneBeee/SkBriggy/wiki/Registering-New-Command</link>",
+    "\nNotes:",
+    "\nFormat: 'brig command /commandName <brigArgType> [<brigArgType(optional)>] <argName:brigArgType> [<argName:brigArgType(optional)>]:'",
+    "\n`commandName` = Represents the command itself, ex: '/mycommand'.",
+    "\n`brigArgType` = Represents a brig argument type.",
+    "While some may match Skript types, this doesn't actually support Skript types.",
+    "\n`argName` = The name of the arg, which will be used to create a local variable for the arg.",
+    "In some cases this will show when typing out a command in game.",
+    "If this isn't set a local variable will be created using the type (see examples).",
+    "\nJust like Skript commands, wrapping your arg in `[]` makes it optional. Do note at this time there is no support for defaults.",
+    "\n",
+    "\nEntries and Sections:",
+    "\n`permission:` = Just like Skript, the permission the player will require for this command.",
+    "\n`description:` = Just like Skript, this is a string that will be used in the help command.",
+    "\n`arguments:` = Section for registering arguments. See `Register Argument` effect.",
+    "\n`trigger:` = Section, just like Skript, for executing your code in the command."})
 @Examples({"brig command /move <player> <location>:",
-        "\ttrigger:",
-        "\t\tteleport {_player} to {_location}",
-        "",
-        "brig command /move <p1:player> <p2:player>:",
-        "\ttrigger:",
-        "\t\tteleport {_p1} to {_p2}",
-        "",
-        "brig command /i <item> [<amount:int>]:",
-        "\ttrigger:",
-        "\t\tset {_amount} to 1 if {_amount} isn't set",
-        "\t\tgive {_amount} of {_item} to player"})
+    "\ttrigger:",
+    "\t\tteleport {_player} to {_location}",
+    "",
+    "brig command /move <p1:player> <p2:player>:",
+    "\ttrigger:",
+    "\t\tteleport {_p1} to {_p2}",
+    "",
+    "brig command /i <item> [<amount:int>]:",
+    "\ttrigger:",
+    "\t\tset {_amount} to 1 if {_amount} isn't set",
+    "\t\tgive {_amount} of {_item} to player"})
 @Since("1.0.0")
 public class StructBrigCommand extends Structure {
 
+    private static final SkBriggy PLUGIN = SkBriggy.getInstance();
     private static final Pattern ALIASES_PATTERN = Pattern.compile("\\s*,\\s*");
     private static final Pattern ARGUMENT_PATTERN = Pattern.compile("\\[?<.*?>]?");
 
     static {
         EntryValidator entryValidator = EntryValidator.builder()
-                .addEntry("permission", null, true)
-                .addEntry("description", "SkBriggy Command", true)
-                .addEntryData(new VariableStringEntryData("usage", null, true))
-                .addEntryData(new KeyValueEntryData<List<String>>("aliases", new ArrayList<>(), true) {
-                    @SuppressWarnings("NullableProblems")
-                    @Override
-                    protected List<String> getValue(String value) {
-                        value = value.replace("/", "");
-                        List<String> aliases = new ArrayList<>(Arrays.asList(ALIASES_PATTERN.split(value)));
-                        if (aliases.get(0).isEmpty()) return null;
-                        return aliases;
-                    }
-                })
-                .addSection("arguments", true)
-                .addSection("trigger", false)
-                .build();
+            .addEntry("permission", null, true)
+            .addEntry("description", "SkBriggy Command", true)
+            .addEntryData(new VariableStringEntryData("usage", null, true))
+            .addEntryData(new KeyValueEntryData<List<String>>("aliases", new ArrayList<>(), true) {
+                @SuppressWarnings("NullableProblems")
+                @Override
+                protected List<String> getValue(String value) {
+                    value = value.replace("/", "");
+                    List<String> aliases = new ArrayList<>(Arrays.asList(ALIASES_PATTERN.split(value)));
+                    if (aliases.get(0).isEmpty()) return null;
+                    return aliases;
+                }
+            })
+            .addSection("arguments", true)
+            .addSection("trigger", false)
+            .build();
         Skript.registerStructure(StructBrigCommand.class, entryValidator, "brig[(gy|adier)] command /<.+>");
     }
 
@@ -158,7 +161,9 @@ public class StructBrigCommand extends Structure {
 
         // Build command
         brigCommand.addExecution(trigger);
-        brigCommand.build();
+
+        // Run later to prevent reload issues
+        Bukkit.getScheduler().runTaskLater(PLUGIN, brigCommand::build, 0);
 
         getParser().deleteCurrentEvent();
         return true;
@@ -215,7 +220,7 @@ public class StructBrigCommand extends Structure {
             }
             if (brigArgument.getArgClass() == MultiLiteralArgument.class) {
                 Skript.error("<" + arg + "> arguments cannot be used in a command. " +
-                        "You can use them in the arguments section instead.");
+                    "You can use them in the arguments section instead.");
                 return false;
             }
 

--- a/src/main/java/com/shanebeestudios/briggy/skript/types/Types.java
+++ b/src/main/java/com/shanebeestudios/briggy/skript/types/Types.java
@@ -14,6 +14,8 @@ import org.bukkit.command.CommandSender;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.function.Predicate;
+
 @SuppressWarnings("unused")
 public class Types {
 
@@ -79,6 +81,15 @@ public class Types {
                         "\t\t\tmake 1 of {_particle} at {_loc} with extra 0")
                 .since("1.1.0")
                 .parser(getDefaultParser()));
+
+        if (Classes.getExactClassInfo(Predicate.class) == null) {
+            Classes.registerClass(new ClassInfo<>(Predicate.class, "predicate")
+                    .user("predicates?")
+                    .name("Predicate")
+                    .description("Represents a predicate which can be used for filtering.")
+                    .since("INSERT VERSION")
+                    .parser(getDefaultParser()));
+        }
     }
 
     /**

--- a/src/main/java/com/shanebeestudios/briggy/skript/types/Types.java
+++ b/src/main/java/com/shanebeestudios/briggy/skript/types/Types.java
@@ -87,7 +87,7 @@ public class Types {
                     .user("predicates?")
                     .name("Predicate")
                     .description("Represents a predicate which can be used for filtering.")
-                    .since("INSERT VERSION")
+                    .since("1.3.0")
                     .parser(getDefaultParser()));
         }
     }

--- a/src/main/resources/lang/english.lang
+++ b/src/main/resources/lang/english.lang
@@ -4,3 +4,4 @@ types:
     intrange: int range¦s @an
     brigarg: brig arg¦s
     particledata: particle data¦s
+    predicate: predicate¦s


### PR DESCRIPTION
Temp changelog

## NOTE:
- Will wait for Minecraft 1.20.5 to release and CommandAPI to update before actually releasing this release.

## ADDED:
- Added support for Minecraft 1.20.5/6
- Added support for getting the previously typed args when using argument registration section (you can get them by `brig-arg-number` and local variables)
- Predicate:
  - Added predicate type
  - Added Block and ItemStack predicate argument types
  - Added expression to filter Blocks/ItemStacks by predicate
  - Added condition to check if Blocks/ItemStacks match predicate

## CHANGED:
- Changed world type to correctly update if a world is loaded/unloaded

## FIXED:
- Fixed the annoying error when reloading a script with an brig command